### PR TITLE
DTSW-7954-Update-dt-ros2-core-dependencies

### DIFF
--- a/dependencies-py3.txt
+++ b/dependencies-py3.txt
@@ -1,7 +1,7 @@
 # LIST YOUR PYTHON3 PACKAGES HERE
 
 # duckiedrone nodes
-filterpy
+filterpy==1.4.5
 simple-pid<=2.0.1
 numpy-quaternion==2023.0.4
 
@@ -9,7 +9,7 @@ numpy-quaternion==2023.0.4
 
 duckietown-utils-ente==7.0.0
 
-git+https://github.com/duckietown/lib-dt-computer-vision.git@ente
+lib-dt-computer-vision==1.0.1
 lib-dt-state-estimation==0.0.10
 
 #### TODO: fix numpy version in lib-dt-modeling #116


### PR DESCRIPTION
This pull request updates the Python dependencies in `dependencies-py3.txt` to use specific version pins and replaces a GitHub dependency with a versioned package. These changes help ensure reproducibility and stability in the project environment.

Dependency version pinning:

* Pinned `filterpy` to version `1.4.5` to avoid unexpected updates.
* Changed `lib-dt-computer-vision` from a GitHub source reference to the released version `1.0.1` on PyPI for improved dependency management.